### PR TITLE
Update minimal-launchpad to be compatible with Java 17

### DIFF
--- a/integration-test/minimal-launchpad/changes.xml
+++ b/integration-test/minimal-launchpad/changes.xml
@@ -23,6 +23,12 @@
     xsi:schemaLocation="http://maven.apache.org/changes/1.0.0 http://maven.apache.org/plugins/maven-changes-plugin/xsd/changes-1.0.0.xsd">
   <body>
 
+    <release version="1.3.0" date="not released">
+      <action type="update" dev="ssauder">
+        Update launchpad.base to 7.0.3-2.7.6 to be compatible with Java 17.
+      </action>
+    </release>
+
     <release version="1.2.0" date="2019-06-03">
       <action type="update" dev="sseifert">
         Update dependencies in launchpad to be compatible with Java 11.

--- a/integration-test/minimal-launchpad/pom.xml
+++ b/integration-test/minimal-launchpad/pom.xml
@@ -31,7 +31,7 @@
 
   <groupId>io.wcm.caravan</groupId>
   <artifactId>io.wcm.caravan.integration-test.minimal-launchpad</artifactId>
-  <version>1.2.1-SNAPSHOT</version>
+  <version>1.3.0-SNAPSHOT</version>
   <packaging>slingfeature</packaging>
 
   <name>Minimal Launchpad for wcm.io Caravan Integration Tests</name>

--- a/integration-test/minimal-launchpad/src/main/provisioning/launchpad.txt
+++ b/integration-test/minimal-launchpad/src/main/provisioning/launchpad.txt
@@ -2,7 +2,7 @@
 # Only a single artifact is allowed within this feature.
 
 [feature name=:launchpad]
-  org.apache.sling/org.apache.sling.launchpad.base/6.0.2-2.6.36
+  org.apache.sling/org.apache.sling.launchpad.base/7.0.3-2.7.6
 
 [settings]
   org.osgi.framework.system.packages=org.osgi.framework;version="1.9",org.osgi.framework.dto;version="1.8";uses:="org.osgi.dto",org.osgi.framework.hooks.bundle;version="1.1";uses:="org.osgi.framework",org.osgi.framework.hooks.resolver;version="1.0";uses:="org.osgi.framework.wiring",org.osgi.framework.hooks.service;version="1.1";uses:="org.osgi.framework",org.osgi.framework.hooks.weaving;version="1.1";uses:="org.osgi.framework.wiring",org.osgi.framework.launch;version="1.2";uses:="org.osgi.framework",org.osgi.framework.namespace;version="1.1";uses:="org.osgi.resource",org.osgi.framework.startlevel;version="1.0";uses:="org.osgi.framework",org.osgi.framework.startlevel.dto;version="1.0";uses:="org.osgi.dto",org.osgi.framework.wiring;version="1.2";uses:="org.osgi.framework,org.osgi.resource",org.osgi.framework.wiring.dto;version="1.3";uses:="org.osgi.dto,org.osgi.resource.dto",org.osgi.resource;version="1.0",org.osgi.resource.dto;version="1.0";uses:="org.osgi.dto",org.osgi.service.packageadmin;version="1.2";uses:="org.osgi.framework",org.osgi.service.startlevel;version="1.1";uses:="org.osgi.framework",org.osgi.service.url;version="1.0",org.osgi.service.resolver;version="1.1";uses:="org.osgi.resource",org.osgi.dto;version="1.1",org.osgi.util.tracker;version="1.5.2";uses:="org.osgi.framework"{dollar}{sling.jre-{dollar}{java.specification.version}}{dollar}{sling.jre-{dollar}{felix.detect.jpms}}


### PR DESCRIPTION
While upgrading dependencies in https://github.com/wcm-io-caravan/caravan-rhyme to be compatible with java 17 I run into a problem that the Sling launchpad wouldn't start up:

````
06.01.2022 08:00:18.868 *ERROR* [FelixStartLevel] ERROR: Bundle '18' EventDispatcher: Error during dispatch. (java.lang.ExceptionInInitializerError)
java.lang.ExceptionInInitializerError
	at org.apache.felix.framework.URLHandlers.createURLStreamHandler(URLHandlers.java:513)
	at java.base/java.net.URL.getURLStreamHandler(URL.java:1436)
	at java.base/java.net.URL.<init>(URL.java:680)
	at java.base/java.net.URL.fromURI(URL.java:748)
	at java.base/java.net.URI.toURL(URI.java:1139)
	at org.apache.sling.installer.core.impl.InternalResource.create(InternalResource.java:87)
	at org.apache.sling.installer.core.impl.OsgiInstallerImpl.createResources(OsgiInstallerImpl.java:384)
	at org.apache.sling.installer.core.impl.OsgiInstallerImpl.registerResources(OsgiInstallerImpl.java:477)
	at org.apache.sling.launchpad.installer.impl.LaunchpadConfigInstaller.install(LaunchpadConfigInstaller.java:207)
	at org.apache.sling.launchpad.installer.impl.LaunchpadConfigInstaller.install(LaunchpadConfigInstaller.java:150)
	at org.apache.sling.launchpad.installer.impl.ServicesListener.notifyChange(ServicesListener.java:100)
	at org.apache.sling.launchpad.installer.impl.ServicesListener$Listener.retainService(ServicesListener.java:182)
	at org.apache.sling.launchpad.installer.impl.ServicesListener$Listener.serviceChanged(ServicesListener.java:205)
	at org.apache.felix.framework.EventDispatcher.invokeServiceListenerCallback(EventDispatcher.java:990)
	at org.apache.felix.framework.EventDispatcher.fireEventImmediately(EventDispatcher.java:838)
	at org.apache.felix.framework.EventDispatcher.fireServiceEvent(EventDispatcher.java:545)
	at org.apache.felix.framework.Felix.fireServiceEvent(Felix.java:4833)
	at org.apache.felix.framework.Felix.registerService(Felix.java:3804)
	at org.apache.felix.framework.BundleContextImpl.registerService(BundleContextImpl.java:328)
	at org.apache.sling.installer.core.impl.Activator.start(Activator.java:80)
	at org.apache.felix.framework.util.SecureAction.startActivator(SecureAction.java:698)
	at org.apache.felix.framework.Felix.activateBundle(Felix.java:2402)
	at org.apache.felix.framework.Felix.startBundle(Felix.java:2308)
	at org.apache.felix.framework.Felix.setActiveStartLevel(Felix.java:1539)
	at org.apache.felix.framework.FrameworkStartLevelImpl.run(FrameworkStartLevelImpl.java:308)
	at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: java.lang.RuntimeException: Unable to make protected boolean java.net.URLStreamHandler.equals(java.net.URL,java.net.URL) accessible: module java.base does not "opens java.net" to unnamed module @58651fd0
	at org.apache.felix.framework.URLHandlersStreamHandlerProxy.<clinit>(URLHandlersStreamHandlerProxy.java:104)
	... 26 more
Caused by: java.lang.reflect.InaccessibleObjectException: Unable to make protected boolean java.net.URLStreamHandler.equals(java.net.URL,java.net.URL) accessible: module java.base does not "opens java.net" to unnamed module @58651fd0
	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:354)
	at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:297)
	at java.base/java.lang.reflect.Method.checkCanSetAccessible(Method.java:199)
	at java.base/java.lang.reflect.Method.setAccessible(Method.java:193)
	at org.apache.felix.framework.util.SecureAction.setAccesssible(SecureAction.java:871)
	at org.apache.felix.framework.URLHandlersStreamHandlerProxy.<clinit>(URLHandlersStreamHandlerProxy.java:79)
	... 26 more
````

Surprisingly the first attempt to fix this by simply upgrading org.apache.sling.launchpad.base to the latest version actually worked. I would have expected more of the dependencies in the minimal-launchpad would need to be adjusted, but the launchpad does start up with all bundles, and the integration tests are passing as well. 

The only other bit I had to adjust was to override the jvmOpts, because the defaults contain "-XX:MaxPermSize=256m" which causes the JVM to immediately exit:

https://github.com/wcm-io-caravan/caravan-rhyme/commit/e9477793c93249055586b4ed731cf12148a3d0c4

I've added a java17 build to the https://github.com/wcm-io-caravan/caravan-rhyme/tree/feature/java-17-compatibility branch, which currently fails because of the missing 1.3.0-SNAPSHOT of the minimal-launchpad to pass.

Not sure if I am missing anything, but it seems that this minor adjustment would be enough to fix this.