### PR TITLE
Update relative path to parent pom

### DIFF
--- a/parent_toplevel/pom.xml
+++ b/parent_toplevel/pom.xml
@@ -26,7 +26,7 @@
     <groupId>io.wcm.caravan.maven</groupId>
     <artifactId>io.wcm.caravan.maven.caravan-global-parent</artifactId>
     <version>17-SNAPSHOT</version>
-    <relativePath />
+    <relativePath>../maven/caravan-global-parent/pom.xml</relativePath>
   </parent>
 
   <groupId>io.wcm.caravan</groupId>


### PR DESCRIPTION
I cannot initially build the source without this fix.

To reproduce:
- Clear all `io.wcm.*` artifacts from local repository:
`rm -r ~/.m2/repository/io/wcm/`
- Execute build
`mvn clean install`

This leads to:
```
[INFO] Scanning for projects...
[ERROR] [ERROR] Some problems were encountered while processing the POMs:
[FATAL] Non-resolvable parent POM for io.wcm.caravan:io.wcm.caravan.parent_toplevel:1.4.0-SNAPSHOT: Could not find artifact io.wcm.caravan.maven:io.wcm.caravan.maven.caravan-global-parent:pom:17-SNAPSHOT and 'parent.relativePath' points at no local POM @ io.wcm.caravan:io.wcm.caravan.parent_toplevel:1.4.0-SNAPSHOT, /home/ckumpe/git/caravan/caravan-tooling/parent_toplevel/pom.xml, line 25, column 11
 @ 
[ERROR] The build could not read 1 project -> [Help 1]
[ERROR]   
[ERROR]   The project io.wcm.caravan:io.wcm.caravan.tooling:1 (/home/ckumpe/git/caravan/caravan-tooling/pom.xml) has 1 error
[ERROR]     Non-resolvable parent POM for io.wcm.caravan:io.wcm.caravan.parent_toplevel:1.4.0-SNAPSHOT: Could not find artifact io.wcm.caravan.maven:io.wcm.caravan.maven.caravan-global-parent:pom:17-SNAPSHOT and 'parent.relativePath' points at no local POM @ io.wcm.caravan:io.wcm.caravan.parent_toplevel:1.4.0-SNAPSHOT, /home/ckumpe/git/caravan/caravan-tooling/parent_toplevel/pom.xml, line 25, column 11 -> [Help 2]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/ProjectBuildingException
[ERROR] [Help 2] http://cwiki.apache.org/confluence/display/MAVEN/UnresolvableModelException
```

With the updated `<relativePath>` to the parent pom the initial build succeeds.